### PR TITLE
Added PONG responses in TwitchCommandManager when a PING is revieved

### DIFF
--- a/TwitchChatInteractions/Scripts/Runtime/Twitch/TwitchCommandManager.cs
+++ b/TwitchChatInteractions/Scripts/Runtime/Twitch/TwitchCommandManager.cs
@@ -149,6 +149,14 @@ namespace TwitchIntegration
             var message = _streamReader.ReadLine();
             if (message == null) return;
 
+            //https://dev.twitch.tv/docs/irc/#keepalive-messages
+            //The client needs to respond to PING messages, or it will disconnect
+            if (message.StartsWith("PING "))
+            {
+                _streamWriter.WriteLine("PONG " + message.Substring(5));
+                _streamWriter.Flush();
+            }
+
             if (message.Contains(UserMessageCode))
                 OnMessageReceived(message);
             else if (message.Contains(UserJoinCode))


### PR DESCRIPTION
Not sure if anyone else has had this issue, but for me the TwitchCommandManager disconnected from the chat after 5-10 minutes of play. Looking up the twitch documentation, I saw the Keeplive messages section, and could not see it beeing implemented anywhere. https://dev.twitch.tv/docs/irc/#keepalive-messages
After implementing PONG responses, the TwitchCommandManager keeps the connection alive for 24h + (didnt test any longer).