### PR TITLE
Listen to all addresses on a port, instead of a specific local IP

### DIFF
--- a/Assets/TwitchChatInteractions/Scripts/Editor/TwitchCommandsEditor.cs
+++ b/Assets/TwitchChatInteractions/Scripts/Editor/TwitchCommandsEditor.cs
@@ -274,8 +274,9 @@ namespace TwitchIntegrationEditor
             });
             
             _redirectUriError = new HelpBox("The redirect URI must end with a forward slash ('/')! " +
+                                            "Correct address with a port should look like: http://localhost:8080/ " +
                                             "Make sure it is written exactly as is in the list of OAuth Redirect URLs " +
-                                            "in your Twitch Application settings.", HelpBoxMessageType.Error);
+                                            "in your Twitch Application settings, with port included.", HelpBoxMessageType.Error);
 
             _portWarning = new HelpBox("In case of errors in authentication, try changing the redirect URI to include a " +
                                        "port (a set of 4-5 numbers separated by a colon from the end of the url, " + 

--- a/Assets/TwitchChatInteractions/Scripts/Runtime/Twitch/TwitchAuthenticator.cs
+++ b/Assets/TwitchChatInteractions/Scripts/Runtime/Twitch/TwitchAuthenticator.cs
@@ -64,9 +64,9 @@ namespace TwitchIntegration
         private IEnumerator TryAuthenticateCoroutine(Action<bool> onComplete)
         {
             _listener = new HttpListener();
-            string redirectUri = _settings.redirectUri;
-            int port = new Uri(redirectUri).Port;
-            if (port == -1)
+            var redirectUri = _settings.redirectUri;
+            var port = new Uri(redirectUri).Port;
+            if (port < 999)
             {
                 Debug.LogError("Port for redirect URI is not set! Defaulting to :3001");
                 port = 3001;
@@ -83,8 +83,8 @@ namespace TwitchIntegration
 
             IsAuthenticated = false;
 
-            string url = "https://id.twitch.tv/oauth2/authorize?client_id=" + _settings.clientId +
-                         "&redirect_uri=" + redirectUri + "&response_type=token&scope=chat:read%20chat:edit";
+            var url = "https://id.twitch.tv/oauth2/authorize?client_id=" + _settings.clientId +
+                      "&redirect_uri=" + redirectUri + "&response_type=token&scope=chat:read%20chat:edit";
 
 #if UNITY_WEBGL
             var webglURL = string.Format("window.open(\"{0}\")", url);
@@ -93,10 +93,10 @@ namespace TwitchIntegration
             Application.OpenURL(url);
 #endif
 
-            float processStartTime = Time.realtimeSinceStartup;
+            var processStartTime = Time.realtimeSinceStartup;
             while (!IsAuthenticated)
             {
-                float elapsedTime = Time.realtimeSinceStartup - processStartTime;
+                var elapsedTime = Time.realtimeSinceStartup - processStartTime;
                 if (elapsedTime >= Timeout)
                 {
                     Log("Authentication timed out", "red");


### PR DESCRIPTION
This fixes #9 
Problem is firefox (probably) translates localhost to 127.0.0.1, and we didn't listen for this address.
Now instead, we will be using localhost:3001 and listening for everything on this port.